### PR TITLE
Add giropay

### DIFF
--- a/pretix_payone/payment.py
+++ b/pretix_payone/payment.py
@@ -13,6 +13,7 @@ from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext_lazy as _
 from json import JSONDecodeError
+from localflavor.generic.forms import IBANFormField
 from pretix.base.decimal import round_decimal
 from pretix.base.forms import SecretKeySettingsField
 from pretix.base.forms.questions import guess_country
@@ -89,8 +90,8 @@ class PayoneSettingsHolder(BasePaymentProvider):
             ("eps", _("eps")),  # ???
             ("sofort", _("SOFORT")),
             ("ideal", _("iDEAL")),
+            ("giropay", _("giropay")),
             # disabled because they are untested
-            # ("giropay", _("giropay")),
             # ("przelewy24", _("Przelewy24")),
             # ("multibanco", _("Multibanco")),
             # ("bancontact", _("Bancontact")),
@@ -633,6 +634,39 @@ class PayoneGiropay(PayoneMethod):  # untested
     onlinebanktransfertype = "GPY"
     onlinebanktransfer_countries = ("DE",)
 
+    def _get_payment_params(self, request, payment):
+        d = super()._get_payment_params(request, payment)
+        d["iban"] = request.session["payment_payone_giropay_iban"]
+        return d
+
+    @property
+    def payment_form_fields(self):
+        return OrderedDict(
+            [
+                (
+                    "iban",
+                    IBANFormField(
+                        label=_("IBAN"),
+                        include_countries=["DE"],
+                        help_text=_("Please enter a german IBAN starting with DE"),
+                    ),
+                ),
+            ]
+        )
+
+    def checkout_prepare(self, request, cart):
+        form = self.payment_form(request)
+        if form.is_valid():
+            request.session["payment_payone_giropay_iban"] = form.cleaned_data["iban"]
+            return super().checkout_prepare(request, cart)
+        return False
+
+    def payment_is_valid_session(self, request):
+        return (
+            super().payment_is_valid_session(request)
+            and request.session.get("payment_payone_giropay_iban", "") != ""
+        )
+
 
 class PayoneEPS(PayoneMethod):
     method = "eps"
@@ -906,7 +940,7 @@ Test status:
 CC: works
 CC 3DS: works
 eps: works
-giropay: fails "invalid account data"
+giropay: works (although only in live mode)
 SOFORT: works
 SEPA DEBIT: unimplemented
 PayPal: works


### PR DESCRIPTION
This PR adds support for Giropay - not thanks to PayOne for their non-existing documentation on this subject.

Things to note:
- GiroSolution/S-Public Services has deprecated the giropay flow, where a BIC or IBAN has to be provided and the user is directly directed to their banks login page. Instead, the user is supposed to be directed to a giropay-provided selection page. Of course, PayOne does not support this flow.
- GiroSolution/S-Public Services does provide a dedicated endpoint for validating if a certain BIC is participating in giropay as a fallback for older integrations. But it is only available for direct giropay integrations. PayOne does not seem to offer such a check - instead providing an unsupported IBAN will just fail the payment.

I have contacted GiroSolution/S-Public Services to verify with them, if there is perhaps a "magic IBAN" that forces the bank selection screen - although I am not holding my breath on this. I have also asked them if there is another way to check a banks participation if the official API cannot be used. An answer is still outstanding on this.

(Of course, we could just create a test-project in the GiroCockpit and ship the token with the PayOne plugin, so that it can verify the bank's participation. But that's mixing two separate entities and feels quite a lot like black magic...)