### PR TITLE
fix access to wrong field names in unused code

### DIFF
--- a/pretix_payone/payment.py
+++ b/pretix_payone/payment.py
@@ -458,11 +458,11 @@ class PayoneMethod(BasePaymentProvider):
 
         if self.invoice_address_mandatory:
             if ia.name_parts.get("salutation"):
-                d["salutation"] = ia.get("salutation", "")[:10]
+                d["salutation"] = ia.name_parts.get("salutation", "")[:10]
             if ia.name_parts.get("title"):
-                d["title"] = ia.get("title", "")[:20]
-            if ia.address:
-                d["street"] = ia.address[:50]
+                d["title"] = ia.name_parts.get("title", "")[:20]
+            if ia.street:
+                d["street"] = ia.street[:50]
             if ia.zipcode:
                 d["zip"] = ia.zipcode[:10]
             if ia.city:


### PR DESCRIPTION
The fields accessed do not exist (`InvoiceAddress` has neither a `get` method nor an `address`). However, this whole `if self.invoice_address_mandatory` clause is never executed because none of the payment methods has `invoice_address_mandatory` set. I only noticed when trying to copy over this part of the code to another payment method.

So we can fix this either by changing the field accesses or removing the whole clause?